### PR TITLE
Add an option to customize the "know more" link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you want to have a custom message you have some options available :
     cookieUrl:      "path/to/info-page.html",
     messageTitle:   "Cookies",
     messageContent: "By continuing your visit to our site, you agree to (...) and make visits statistics.",
+    findOutMore:    "Find out more",
     cookieName:     "cookies_law",
   });
 ```

--- a/source/assets/javascripts/jquery-law.js.coffee
+++ b/source/assets/javascripts/jquery-law.js.coffee
@@ -9,13 +9,14 @@ class @AlertLaw
     @messageTitle   = options.messageTitle   ? 'Cookies'
     @messageContent = options.messageContent ? 'En poursuivant votre navigation sur notre site, vous en acceptez l‘utilisation pour vous proposer un service personnalisé, des publicités ciblées adaptées à vos centres d’intérêts et réaliser des statistiques de visites.'
     @cookieName     = options.cookieName     ? 'cookies_law'
+    @findOutMore    = options.findOutMore    ? 'En savoir plus'
 
   buildAlert: ->
     "<div id='js-law--alert' style='display: none;'>
       <a href='#' id='js-law--close'>&#10006;</a>
       <p class='m-law--title'>#{@messageTitle}</p>
       <p>#{@messageContent}</p>
-      <a href='#{@cookieUrl}'>En savoir plus</a>
+      <a href='#{@cookieUrl}'>#{@findOutMore}</a>
     </div>"
 
   cookieAlreadyAccepted: ->


### PR DESCRIPTION
Hi, I have added a new option to the plugin so it is possible to customize the message of the "En savoir plus" link. It always showed up un french, and the only way to change it was to override the `buildAlert` method through the `prototype`. No need for that with this new option.
